### PR TITLE
Improved error handling.

### DIFF
--- a/src/InfoTrack.OAuth/InfoTrack.OAuth.csproj
+++ b/src/InfoTrack.OAuth/InfoTrack.OAuth.csproj
@@ -8,7 +8,7 @@
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
     <Authors>InfoTrack</Authors>
     <Product>InfoTrack CachingTokenClient</Product>
-    <Description>Supporting library for InfoTrack.CachingTokenClient. You should install InfoTrack.OAuth.CachingTokenClient.DotNetCore or InfoTrack.OAuth.CachingTokenClient.DotNetFramework instead.</Description>
+    <Description>OAuth Token Client Library.</Description>
     <PackageProjectUrl>https://github.com/InfoTrackGlobal/CachingTokenClient</PackageProjectUrl>
     <PackageTags>oauth</PackageTags>
   </PropertyGroup>

--- a/src/InfoTrack.OAuth/InfoTrack.OAuth.csproj
+++ b/src/InfoTrack.OAuth/InfoTrack.OAuth.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.2</TargetFrameworks>
+    <TargetFrameworks>netstandard1.2;net452</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageLicenseExpression></PackageLicenseExpression>

--- a/src/InfoTrack.OAuth/TokenClient.cs
+++ b/src/InfoTrack.OAuth/TokenClient.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 
@@ -213,9 +214,14 @@ namespace InfoTrack.OAuth
 
             HttpResponseMessage tokenResponse = await HttpClient.SendAsync(request).ConfigureAwait(false);
 
-            var result = await tokenResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+            var responseBody = await tokenResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
 
-            return JsonConvert.DeserializeObject<T>(result);
+            if (!tokenResponse.IsSuccessStatusCode && tokenResponse.StatusCode != HttpStatusCode.BadRequest)
+            {
+                throw new AuthenticationException($"Non-success status code: {tokenResponse.StatusCode}. Response body: {responseBody}");
+            }
+
+            return JsonConvert.DeserializeObject<T>(responseBody);
         }
     }
 }


### PR DESCRIPTION
Allowing 500 errors to bubble up to the consumer by throwing an exception before attempting to deserialise.