### PR TITLE
Added new base abstract method plus implementations for both clients

### DIFF
--- a/src/InfoTrack.OAuth.Caching.DotNetFramework/CachingTokenClient.cs
+++ b/src/InfoTrack.OAuth.Caching.DotNetFramework/CachingTokenClient.cs
@@ -57,5 +57,13 @@ namespace InfoTrack.OAuth.Caching.DotNetFramework
                 _semaphore.Release();
             }
         }
+
+        protected override void InvalidateToken(string key)
+        {
+            if (_cache.Get(key) != null)
+            {
+                _cache.Remove(key);
+            }
+        }
     }
 }

--- a/src/InfoTrack.OAuth.Caching.DotNetStandard/CachingTokenClient.cs
+++ b/src/InfoTrack.OAuth.Caching.DotNetStandard/CachingTokenClient.cs
@@ -29,5 +29,13 @@ namespace InfoTrack.OAuth.Caching.DotNetStandard
                 return item;
             });
         }
+
+        protected override void InvalidateToken(string key)
+        {
+            if (_memoryCache.TryGetValue(key, out var cached) && cached != null)
+            {
+                _memoryCache.Remove(key);
+            }
+        }
     }
 }

--- a/src/InfoTrack.OAuth/BaseCachingTokenClient.cs
+++ b/src/InfoTrack.OAuth/BaseCachingTokenClient.cs
@@ -16,6 +16,8 @@ namespace InfoTrack.OAuth
 
         protected abstract Task<TItem> GetOrCreateAsync<TItem>(string key, Func<CacheItem, Task<TItem>> factory);
 
+        protected abstract void InvalidateToken(string key);
+
         public Task<TokenResponse> ClientCredentialsGrantAsync(Uri tokenEndpoint, string clientId, string clientSecret)
         {
             if (tokenEndpoint == null) throw new ArgumentNullException(nameof(tokenEndpoint));


### PR DESCRIPTION
Currently, if we have a token in the cache, that token will always be used and a request to fetch a new token will never be made. This is a problem as tokens inside the cache can become invalid for... reasons. For this reason I've added a means for removing a token (by it's id) from the cache.

I've looked at both clients and the base class implementation and I think this is the best way to implement this feature. I've added an abstract method to the base class and implemented it in both the .NET Standard and .NET Framework implementations of the client. While the cache implementations are different between the two, removing an item from cache is relatively straight forward and I don't believe it will cause any problems.