### PR TITLE
Add CODEOWNERS file for Global Platform Security

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @InfoTrackGlobal/global-platform-security


### PR DESCRIPTION
This PR adds a CODEOWNERS file to the repo with Global Platform Security as the owner